### PR TITLE
Updates Lombok dependency and project version to 1.18.30

### DIFF
--- a/lombok-maven-plugin/pom.xml
+++ b/lombok-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.projectlombok</groupId>
     <artifactId>lombok-maven</artifactId>
-    <version>1.18.20.1-SNAPSHOT</version>
+    <version>1.18.30.1-SNAPSHOT</version>
   </parent>
 
   <artifactId>lombok-maven-plugin</artifactId>

--- a/lombok-maven-plugin/pom.xml
+++ b/lombok-maven-plugin/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.projectlombok</groupId>
     <artifactId>lombok-maven</artifactId>
-    <version>1.18.30.1-SNAPSHOT</version>
+    <version>1.18.30.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>lombok-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.projectlombok</groupId>
   <artifactId>lombok-maven</artifactId>
-  <version>1.18.30.1-SNAPSHOT</version>
+  <version>1.18.30.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Maven Plugin for Project Lombok</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.projectlombok</groupId>
   <artifactId>lombok-maven</artifactId>
-  <version>1.18.20.1-SNAPSHOT</version>
+  <version>1.18.30.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Maven Plugin for Project Lombok</name>
@@ -68,7 +68,7 @@
     <project.scm.id>awhitford-github-server</project.scm.id>
     <maven.api.minimum>3.3.9</maven.api.minimum>
     <maven.api.version>3.9.1</maven.api.version>
-    <lombok.version>1.18.20</lombok.version>
+    <lombok.version>1.18.30</lombok.version>
     <releaseProfiles>sonatype-oss-release</releaseProfiles>
     <version.java>8</version.java>
   </properties>
@@ -212,7 +212,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.8.8</version>
+          <version>0.8.10</version>
         </plugin>
         <plugin>
           <groupId>org.owasp</groupId>

--- a/test-maven-lombok/pom.xml
+++ b/test-maven-lombok/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.projectlombok</groupId>
     <artifactId>lombok-maven</artifactId>
-    <version>1.18.30.1-SNAPSHOT</version>
+    <version>1.18.30.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.projectlombok.test</groupId>

--- a/test-maven-lombok/pom.xml
+++ b/test-maven-lombok/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.projectlombok</groupId>
     <artifactId>lombok-maven</artifactId>
-    <version>1.18.20.1-SNAPSHOT</version>
+    <version>1.18.30.1-SNAPSHOT</version>
   </parent>
 
   <groupId>org.projectlombok.test</groupId>


### PR DESCRIPTION
This updates the Lombok dependency to version 1.18.30 so that the plugin can support Java 21.

Closes #172.
Closes #174. 
Resolves #179.

# Testing

I could build the project locally and use it to build and test [Google Compute Engine plugin](https://github.com/jenkinsci/google-compute-engine-plugin) for Jenkins.